### PR TITLE
Update Audio_buses.tex

### DIFF
--- a/Audio_buses.tex
+++ b/Audio_buses.tex
@@ -1,55 +1,56 @@
-\section{Audio Buses}
+\section{Canais de Áudio}
 \label{sec:audiobus}
 
-Audio buses are used for routing audio signals. They are like the channels of a mixing board. SuperCollider has 128 audio buses by default. There are also control buses (for control signals), but for now let's focus on audio buses only.\footnote{We will take a quick look at control buses in section \ref{sec:control-buses}.}
+Canais de áudio ("audio buses") são usados para rotear sinais de áudio. É como se fossem os canais de uma mesa de som. O SuperCollider tem 128 canais de áudio como padrão. Também existem canais de controle (para sinais de controle), mas por enquanto vamos nos concentrar só nos canais de áudio.\footnote{Vamos dar uma rápida olhada em canais de controle na seção \ref{sec:control-buses}.}
 
 \begin{figure}[h!]
 \centerline{
 	\includegraphics[scale=0.4]{fig-audio-bus.png}}
-\caption{Audio buses and Meter window in SC.}
+\caption{Canais de áudio e a janela Meter no SC.}
 \label{fig:audio-bus}
 \end{figure}
 
-Hit [ctrl+M] to open up the Meter window. It shows the levels of all inputs and outputs. Figure \ref{fig:audio-bus} shows a screenshot of this window and its correspondence to SuperCollider's default buses. In SuperCollider, audio buses are numbered from 0 to 127. The first eight (0-7) are by default reserved to be the output channels of your sound card. The next eight (8-15) are reserved for the inputs of your sound card. All the others (16 to 127) are free to be used in any way you want, for example, when you need to route audio signals from one UGen to another.
+Pressione [ctrl+M] para abrir a janela Meter ("medidor"). Ela mostra os níveis de todas as entradas e saídas. A figura \ref{fig:audio-bus} mostra uma captura de tela dessa janela e sua correspondência com os canais padrão do SuperCollider. No SC, canais de áudio são numerados de 0 a 127. Os primeiros oito (0-7) são por definição reservados para serem os canais de saída da sua placa de com. Os próximos oito (8-15) são reservados para as entradas da sua placa de som. Todos os outros (16 a 127) estão livres para serem utilizados de qualquer forma que se queira, por exemplo, quando você precisa rotear sinais de áudio de uma UGen para outra.
 
 \subsection{\texttt{Out} and \texttt{In} UGens}
 
-Now try the following line of code:
+Agora experimente a seguinte linha de código:
 
 \begin{lstlisting}[style=SuperCollider-IDE, basicstyle=\scttfamily\footnotesize]
-{Out.ar(1, SinOsc.ar(440, 0, 0.1))}.play; // right channel
+{Out.ar(1, SinOsc.ar(440, 0, 0.1))}.play; // canal direito
 \end{lstlisting}
 
-The \texttt{Out} UGen takes care of routing signals to specific buses.
+A UGen \texttt{Out} UGen cuida do roteamento de sinais para canais específicos.
 
-The first argument to \texttt{Out} is the target bus, that is, where you want this signal to go.  In the example above, the number \texttt{1} means that we want to send the signal to bus 1, which is the right channel of your sound card.
+O primeiro argumento para \texttt{Out} é o canal de destino, isto é, para onde você quer que o sinal vá. No exemplo acima, o número \texttt{1} significa que queremos mandar o sinal para o canal 1, que é o canal direito da sua placa de som.
 
-The second argument of \texttt{Out.ar} is the actual signal that you want to ``write'' into that bus. It can be a single UGen, or a combination of UGens. In the example, it is just a sine wave. You should hear it only on your right speaker (or on your right ear if using headphones).
+O segundo argumento de \texttt{Out.ar} é o sinal de fato que você quer "escrever" neste canal. Pode ser uma única UGen, ou uma combinação de UGens. No exemplo, é somente uma onda senoidal. Você deve ouvi-la somente no seu alto-falante direito (ou seu ouvido direito, se estiver usando fones de ouvido).
 
-With the Meter window open and visible, go ahead and change the first argument of \texttt{Out.ar}: try any number between 0 and 7, and watch the meters. You will see that the signal goes wherever you tell it to.
+Com a janela Meter aberta e visível, vá ao código e mude o primeiro argumento de \texttt{Out.ar}: tente qualquer número entre 0 e 7. Observe os medidores. Você verá que o sinal vai para qualquer lugar que você mandar.
 
 \bigskip
-\todo[inline, color=green!40]{ TIP: Most likely you have a sound card that can only play two channels (left and right), so you will only hear the sine tone when you send it to bus 0 or bus 1. When you send it to other buses (3 to 7), you will still see the corresponding meter showing the signal: SC is in fact sending the sound to that bus, but unless you have an 8-channel sound card you will not be able to hear the output of buses 3-7.}
+\todo[inline, color=green!40]{DICA: É bastante provável que você tenha uma placa de som que só pode tocar dois canais (esquerdo e direito), então você somente escutará a senoide quando mandá-la para o canal 0 ou 1. Se você enviá-la para outros canais (3 a 7), você ainda verá o medidor correspondente mostrando o sinal: o SC está de fato mandando som para aquele canal, mas a menos que você tenha uma placa de som de 8 canais, você não poderá ouvir a saída dos canais 3-7.}
 \bigskip
 
-One simple example of an audio bus being used for an effect is shown below.
+Um exemplo simples de um canal de áudio sendo usado para um efeito é mostrado abaixo.
 
 \begin{lstlisting}[style=SuperCollider-IDE, basicstyle=\scttfamily\footnotesize]
-// start the effect
+// iniciar o efeito
 f = {Out.ar(0, BPF.ar(in: In.ar(55), freq: MouseY.kr(1000, 5000), rq: 0.1))}.play;
-// start the source
+// iniciar a fonte sonora
 n = {Out.ar(55, WhiteNoise.ar(0.5))}.play;
 \end{lstlisting}
 
-The first line declares a synth (stored into the variable \texttt{f}) consisting of a filter UGen (a Band Pass Filter). A band pass filter takes any sound as input, and \emph{filters out all frequencies except the one frequency region that you want to let through}. \texttt{In.ar} is the UGen we use to read from an audio bus; so with \texttt{In.ar(55)} being used as input of the \texttt{BPF}, any sound that we send to bus 55 will be passed to the band pass filter. Notice that this first synth does not make any sound at first: when you evaluate the first line, bus 55 is still empty. It will only make sound when we send some audio into bus 55, which happens on the second line. 
+A primeira linha declara um sintetizador (armazenado na variável \texttt{f}), consistindo em uma UGen de filtro (Band Pass Filter: "filtro passa-banda"). Um filtro passa-banda aceita qualquer som como entrada e \emph{elimina todas as frequências exceto a região de frequência que você quer deixar passar}. \texttt{In.ar} é a UGen que usamos para ler de um canal de áudio. Portanto, com \texttt{In.ar(55)} sendo utilizado como entrada para o \texttt{BPF}, qualquer som que mandarmos para o canal 55 passará pelo filtro passa-banda. Note que o primeiro sintetizador, em um primeiro momento, não produz som algum: quando você roda a primera linha, o canal 55 continua vazio. Ele somente produzirá som quando mandarmos algum audio para o canal 55, que é o que acontece na segunda linha.
 
-The second line creates a synth and stores it into the variable \texttt{n}. This synth simply generates white noise, and outputs it \emph{not to the loudspeakers directly, but to audio bus 55 instead}. That is precisely the bus that our filter synth is listening to, so as soon as you evaluate the second line, you should start hearing the white noise being filtered by synth \texttt{f}.
-In short, the routing looks like this:
+A segunda linha cria um sintetizador e o armazena na variável \texttt{n}. Este sintetizador simplesmente gera ruído branco, e o envia \emph{não diretamente para os alto-falantes, mas sim para o canal de audio 55}. Este é precisamente o canal que nosso sintetizador de filtro está escutando, então assim que você rodar a segunda linha, você deve começar a ouvir o ruído branco sendo filtrado pelo sintetizador \texttt{f}.
+
+Em resumo, o roteamento tem a seguinte configuração: 
 
 \begin{center}
-\emph{noise synth} $\rightarrow$ \emph{bus 55} $\rightarrow$ \emph{filter synth}
+\emph{sintetizador de ruído} $\rightarrow$ \emph{canal 55} $\rightarrow$ \emph{sintetizador de filtro}
 \end{center}
 
-The order of execution is important. The previous example won't work if you evaluate the source \emph{before} the effect. This will be discussed in more detail in section \ref{sec:order-of-execution}, ``Order of Execution.''
+A ordem de execução é importante. O exemplo anterior não funcionará se você não rodar a fonte \emph{antes} do efeito. Isso será discutido em mais detalhe na seção \ref{sec:order-of-execution}, "Ordem de Execução".
 
-One last thing: when you wrote in earlier examples synths like \texttt{\{SinOsc.ar(440)\}.play}, SC was actually doing \texttt{\{Out.ar(0, SinOsc.ar(440))\}.play} under the hood: it assumed you wanted to send the sound out to bus 0, so it automatically wrapped the first UGen with an \texttt{Out.ar(0, ...)} UGen. In fact a few more things are happening there behind the scenes, but we'll come back to this later (section \ref{sec:synthdef}).
+Uma última coisa: quando em exemplos anteriores você escreveu sintetizadores como \texttt{\{SinOsc.ar(440)\}.play}, internamente o SC estava de fato executando \texttt{\{Out.ar(0, SinOsc.ar(440))\}.play}: ele assume que você queria mandar som para o canal 0, então ele automaticamente empacota a primeira UGen em um \texttt{Out.ar(0, ...)} UGen. Na realidade, há mais algumas coisas acontecendo nos bastidores, mas voltaremos a isso mais tarde (seção \ref{sec:synthdef}).


### PR DESCRIPTION
Bruno, há uma atualização a se pensar no texto, na parte que se refere ao Meter.
O texto aqui pressupõe que o Meter já mostre de cara mais os 8 canais.
Pois (acho que do 3.6 em diante) o padrão não é mais abrir 8 canais com um simples s.boot; 
Mesmo com uma placa com mais canais o Meter vai mostrar somente dois in e dois out até que você mude a configuração, com algo como s.options.numInputBusChannels = 4;
s.options.numOutputBusChannels = 4;
(não sei se há um único comando que mude ins e outs de uma vez).
Por ora, apenas traduzo e deixo como está.
Abraço!

Quando aparece para comparar o código anterior com as mudanças, ainda consigo mudar algo? Ou há que se mandar novamente?

Relendo percebi que na entrada 56 ficou uma coisa solta: "empacota em uma {blablablabla} UGen.", certo seria algo como: "empacota na seguinte UGen: {blablabalba}."
No mais, não sei se vc acha que "empacota" é uma boa tradução para wrap. Embrulhar achei pior, e envolver me parece impreciso. Enquadra?
